### PR TITLE
Allow nonfatal tests with summary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,7 @@ test/%.exe: chibicc test/%.c
 	$(CC) -pthread -o $@ test/$*.o -xc test/common
 
 test: $(TESTS)
-	for i in $^; do echo $$i; ./$$i || exit 1; echo; done
-	test/driver.sh ./chibicc
+	test/run_tests.sh ./chibicc $^
 
 test-all: test test-stage2
 
@@ -38,8 +37,7 @@ stage2/test/%.exe: stage2/chibicc test/%.c
 	$(CC) -pthread -o $@ stage2/test/$*.o -xc test/common
 
 test-stage2: $(TESTS:test/%=stage2/test/%)
-	for i in $^; do echo $$i; ./$$i || exit 1; echo; done
-	test/driver.sh ./stage2/chibicc
+	test/run_tests.sh ./stage2/chibicc $^
 
 # Misc.
 

--- a/test/driver.sh
+++ b/test/driver.sh
@@ -5,12 +5,47 @@ tmp=`mktemp -d /tmp/chibicc-test-XXXXXX`
 trap 'rm -rf $tmp' INT TERM HUP EXIT
 echo > $tmp/empty.c
 
+# Track last executed command so we can show it on failures.
+trap 'prev_cmd=$this_cmd; this_cmd=$BASH_COMMAND' DEBUG
+
+success=0
+fail=0
+xfail_count=0
+xpass=0
+
+# List of tests that are expected to fail can be specified via the XFAIL
+# environment variable (space separated names).
+read -a expected_failures <<< "${XFAIL}"
+
+is_expected_failure() {
+    for t in "${expected_failures[@]}"; do
+        if [ "${t}" = "$1" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
 check() {
-    if [ $? -eq 0 ]; then
-        echo "testing $1 ... passed"
+    status=$?
+    if [ $status -eq 0 ]; then
+        if is_expected_failure "$1"; then
+            echo "testing $1 ... unexpected success"
+            ((xpass++))
+        else
+            echo "testing $1 ... passed"
+            ((success++))
+        fi
     else
-        echo "testing $1 ... failed"
-        exit 1
+        if is_expected_failure "$1"; then
+            echo "testing $1 ... expected failure"
+            echo "  command: $prev_cmd"
+            ((xfail_count++))
+        else
+            echo "testing $1 ... failed"
+            echo "  command: $prev_cmd"
+            ((fail++))
+        fi
     fi
 }
 
@@ -279,7 +314,12 @@ echo 'extern int bar; int foo() { return bar; }' > $tmp/foo.c
 echo 'int foo(); int bar=3; int main() { foo(); }' > $tmp/bar.c
 $chibicc -static -o $tmp/foo $tmp/foo.c $tmp/bar.c
 check -static
-file $tmp/foo | grep -q 'statically linked'
+if command -v file >/dev/null 2>&1; then
+    file $tmp/foo | grep -q 'statically linked'
+else
+    # Fallback: use ldd to verify static linking when 'file' is unavailable
+    ldd $tmp/foo 2>&1 | grep -q 'not a dynamic executable'
+fi
 check -static
 
 # -shared
@@ -309,4 +349,8 @@ echo 'int main() {}' | $chibicc -c -o $tmp/baz.o -xc -
 cc -Xlinker -z -Xlinker muldefs -Xlinker --gc-sections -o $tmp/foo $tmp/foo.o $tmp/bar.o $tmp/baz.o
 check -Xlinker
 
-echo OK
+echo "Driver summary:"
+echo "  Passed: $success"
+echo "  Expected failures: $xfail_count"
+echo "  Unexpected successes: $xpass"
+echo "  Failed: $fail"

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Run all test executables and the driver script without stopping on failure.
+
+chibicc=$1
+shift
+
+test_exes=("$@")
+
+# Expected failures from XFAIL environment variable (space separated)
+IFS=' ' read -r -a expected_failures <<< "${XFAIL}"
+
+is_expected_failure() {
+    for t in "${expected_failures[@]}"; do
+        if [ "${t}" = "$1" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+pass=0
+fail=0
+xfail_count=0
+xpass=0
+
+for exe in "${test_exes[@]}"; do
+    echo "running $exe"
+    cmd="./$exe"
+    if output=$($cmd 2>&1); then
+        if is_expected_failure "$exe"; then
+            echo "  unexpected success"
+            ((xpass++))
+        else
+            echo "  passed"
+            ((pass++))
+        fi
+    else
+        if is_expected_failure "$exe"; then
+            echo "  expected failure"
+            echo "$output"
+            ((xfail_count++))
+        else
+            echo "  failed"
+            echo "$output"
+            ((fail++))
+        fi
+    fi
+    echo
+done
+
+# Run the driver script
+if [ -f test/driver.sh ]; then
+    test/driver.sh "$chibicc"
+fi
+
+echo "Summary:"
+echo "  Passed: $pass"
+echo "  Expected failures: $xfail_count"
+echo "  Unexpected successes: $xpass"
+echo "  Failed: $fail"
+
+exit 0


### PR DESCRIPTION
## Summary
- continue test execution even when failures occur
- add a helper script to run tests and keep going
- capture failing command information in `driver.sh`
- update Makefile to use the new script
- handle missing `file` command when checking static executables

## Testing
- `make test`
- `make test-stage2`
